### PR TITLE
perform concurrent axios request to retrieve separated regular season and postseason game data

### DIFF
--- a/src/components/GamesInfoComponent.vue
+++ b/src/components/GamesInfoComponent.vue
@@ -111,28 +111,21 @@ import { nameRetroizer, abbreviationRetroizer } from '../modules/retroizer';
                 }
                 // TODO: make per_page and page parameters dynamic                    
                 Promise.all([
-                    axios.get("https://free-nba.p.rapidapi.com/games?seasons[]=" + this.season + "&team_ids[]=" + this.team_ids + "&postseason=false&per_page=100&page=1",{ headers }),
-                    axios.get("https://free-nba.p.rapidapi.com/games?seasons[]=" + this.season + "&team_ids[]=" + this.team_ids + "&postseason=true&per_page=100&page=1",{ headers })
-                    ])
+                    axios.get("https://free-nba.p.rapidapi.com/games?seasons[]=" + this.season + "&team_ids[]=" + this.team_ids + "&postseason=false&per_page=100&page=1", { headers }),
+                    axios.get("https://free-nba.p.rapidapi.com/games?seasons[]=" + this.season + "&team_ids[]=" + this.team_ids + "&postseason=true&per_page=100&page=1", { headers })
+                ])
                     .then(axios.spread((regular_season_response, postseason_response) => {
-                        // sort data by date and format accordingly
+                        // regular season games - sort data by date
                         this.regularSeasonData = this.sortGamesByDate(regular_season_response.data.data);
-                        this.regularSeasonData.forEach((item) => {
-                            item.date = this.dateFormatter(item.date);
-                            item.home_team.full_name = nameRetroizer(this.season, item.home_team.full_name);
-                            item.home_team.abbreviation = abbreviationRetroizer(this.season, item.home_team.abbreviation);
-                            item.visitor_team.full_name = nameRetroizer(this.season, item.visitor_team.full_name);
-                            item.visitor_team.abbreviation = abbreviationRetroizer(this.season, item.visitor_team.abbreviation);
-                        });
 
+                        // regular season games - format dates, and revise for historical teams
+                        this.dateFormatterAndRetroize(this.regularSeasonData);
+
+                        // postseason games - sort data by date
                         this.postSeasonData = this.sortGamesByDate(postseason_response.data.data);
-                        this.postSeasonData.forEach((item) => {
-                            item.date = this.dateFormatter(item.date);
-                            item.home_team.full_name = nameRetroizer(this.season, item.home_team.full_name);
-                            item.home_team.abbreviation = abbreviationRetroizer(this.season, item.home_team.abbreviation);
-                            item.visitor_team.full_name = nameRetroizer(this.season, item.visitor_team.full_name);
-                            item.visitor_team.abbreviation = abbreviationRetroizer(this.season, item.visitor_team.abbreviation);
-                        });
+
+                        // postseason games - format dates, and revise for historical teams
+                        this.dateFormatterAndRetroize(this.postSeasonData);
                     }))
                     .catch(error => {
                         console.log(error);
@@ -149,6 +142,16 @@ import { nameRetroizer, abbreviationRetroizer } from '../modules/retroizer';
             sortGamesByDate(array) {
                 return array.slice()
                     .sort((a, b) => new Date(a.date) - new Date(b.date));
+            },
+
+            dateFormatterAndRetroize(array) {
+                return array.forEach((item) => {
+                    item.date = this.dateFormatter(item.date);
+                    item.home_team.full_name = nameRetroizer(this.season, item.home_team.full_name);
+                    item.home_team.abbreviation = abbreviationRetroizer(this.season, item.home_team.abbreviation);
+                    item.visitor_team.full_name = nameRetroizer(this.season, item.visitor_team.full_name);
+                    item.visitor_team.abbreviation = abbreviationRetroizer(this.season, item.visitor_team.abbreviation);
+                });
             },
 
             dateFormatter(timestamp) {

--- a/src/components/GamesInfoComponent.vue
+++ b/src/components/GamesInfoComponent.vue
@@ -108,23 +108,15 @@ import { nameRetroizer, abbreviationRetroizer } from '../modules/retroizer';
                 const headers = {
                     "X-RapidAPI-Key": "959819e95cmshecf23a99cc98e23p15b9d9jsn5e3fd589ab8a",
                     "X-RapidAPI-Host": "free-nba.p.rapidapi.com",
-                }
-                // TODO: make per_page and page parameters dynamic                    
+                }                 
                 Promise.all([
                     axios.get("https://free-nba.p.rapidapi.com/games?seasons[]=" + this.season + "&team_ids[]=" + this.team_ids + "&postseason=false&per_page=100&page=1", { headers }),
                     axios.get("https://free-nba.p.rapidapi.com/games?seasons[]=" + this.season + "&team_ids[]=" + this.team_ids + "&postseason=true&per_page=100&page=1", { headers })
                 ])
                     .then(axios.spread((regular_season_response, postseason_response) => {
-                        // regular season games - sort data by date
                         this.regularSeasonData = this.sortGamesByDate(regular_season_response.data.data);
-
-                        // regular season games - format dates, and revise for historical teams
                         this.dateFormatterAndRetroize(this.regularSeasonData);
-
-                        // postseason games - sort data by date
                         this.postSeasonData = this.sortGamesByDate(postseason_response.data.data);
-
-                        // postseason games - format dates, and revise for historical teams
                         this.dateFormatterAndRetroize(this.postSeasonData);
                     }))
                     .catch(error => {
@@ -144,6 +136,7 @@ import { nameRetroizer, abbreviationRetroizer } from '../modules/retroizer';
                     .sort((a, b) => new Date(a.date) - new Date(b.date));
             },
 
+            // perform date formatting and retrozing for each card
             dateFormatterAndRetroize(array) {
                 return array.forEach((item) => {
                     item.date = this.dateFormatter(item.date);

--- a/src/components/GamesInfoComponent.vue
+++ b/src/components/GamesInfoComponent.vue
@@ -114,10 +114,8 @@ import { nameRetroizer, abbreviationRetroizer } from '../modules/retroizer';
                     axios.get("https://free-nba.p.rapidapi.com/games?seasons[]=" + this.season + "&team_ids[]=" + this.team_ids + "&postseason=true&per_page=100&page=1", { headers })
                 ])
                     .then(axios.spread((regular_season_response, postseason_response) => {
-                        this.regularSeasonData = this.sortGamesByDate(regular_season_response.data.data);
-                        this.dateFormatterAndRetroize(this.regularSeasonData);
-                        this.postSeasonData = this.sortGamesByDate(postseason_response.data.data);
-                        this.dateFormatterAndRetroize(this.postSeasonData);
+                        this.regularSeasonData = this.cardDisplayCleanup(regular_season_response.data.data);
+                        this.postSeasonData = this.cardDisplayCleanup(postseason_response.data.data);
                     }))
                     .catch(error => {
                         console.log(error);
@@ -130,21 +128,21 @@ import { nameRetroizer, abbreviationRetroizer } from '../modules/retroizer';
         },
 
         methods: {
-            // sorts cards by ascending date order
-            sortGamesByDate(array) {
-                return array.slice()
-                    .sort((a, b) => new Date(a.date) - new Date(b.date));
-            },
-
-            // perform date formatting and retrozing for each card
-            dateFormatterAndRetroize(array) {
-                return array.forEach((item) => {
+            /* 
+            * for each item, format date to YYYY-MM-DD and retroize team(s) as needed
+            * return array of cards by ascending date order
+            */
+            cardDisplayCleanup(array) {
+                array.forEach((item) => {
                     item.date = this.dateFormatter(item.date);
                     item.home_team.full_name = nameRetroizer(this.season, item.home_team.full_name);
                     item.home_team.abbreviation = abbreviationRetroizer(this.season, item.home_team.abbreviation);
                     item.visitor_team.full_name = nameRetroizer(this.season, item.visitor_team.full_name);
                     item.visitor_team.abbreviation = abbreviationRetroizer(this.season, item.visitor_team.abbreviation);
                 });
+
+                return array.slice()
+                    .sort((a, b) => new Date(a.date) - new Date(b.date));
             },
 
             dateFormatter(timestamp) {


### PR DESCRIPTION
Fixes an issue where if a team plays over 100 games in a season (regular season + postseason), any games over the 100 count would not display.