### PR TITLE
differentiate between completed and upcoming games for both regular and post season

### DIFF
--- a/src/components/GamesInfoComponent.vue
+++ b/src/components/GamesInfoComponent.vue
@@ -13,7 +13,10 @@
                 <button class="nav-link" id="regular-season-upcoming-tab" data-bs-toggle="tab" data-bs-target="#regular-season-upcoming" type="button" role="tab" aria-controls="regular-season-upcoming" aria-selected="false">Regular Season - Upcoming</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="playoffs-tab" data-bs-toggle="tab" data-bs-target="#playoffs" type="button" role="tab" aria-controls="playoffs" aria-selected="false">Playoffs</button>
+                <button class="nav-link" id="playoffs-completed-tab" data-bs-toggle="tab" data-bs-target="#playoffs-completed" type="button" role="tab" aria-controls="playoffs-completed" aria-selected="false">Playoffs - Completed</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="playoffs-upcoming-tab" data-bs-toggle="tab" data-bs-target="#playoffs-upcoming" type="button" role="tab" aria-controls="playoffs-upcoming" aria-selected="false">Playoffs - Upcoming</button>
             </li>
         </ul>
         
@@ -52,11 +55,22 @@
                 </div> -->
             </div>
 
-            <div class="tab-pane fade" id="playoffs" role="tabpanel" aria-labelledby="playoffs-tab">
+            <div class="tab-pane fade" id="playoffs-completed" role="tabpanel" aria-labelledby="playoffs-completed-tab">
                 <div class="mt-1" v-if="postSeasonData.length < 1 && displayTabs">
                     <p>No playoffs data available.</p>
                 </div>
-                <div v-else id="postSeasonGameInfo" class="row row-cols-1 row-cols-md-3 g-4 mt-1">
+                <div v-else id="postSeasonCompletedGameInfo" class="row row-cols-1 row-cols-md-3 g-4 mt-1">
+                    <div class="col" v-for="dataPoint in postSeasonData" :key="dataPoint.id">
+                        <GameCardComponent :data = "dataPoint"></GameCardComponent>
+                    </div>
+                </div>
+            </div>
+
+            <div class="tab-pane fade" id="playoffs-upcoming" role="tabpanel" aria-labelledby="playoffs-upcoming-tab">
+                <div class="mt-1" v-if="postSeasonData.length < 1 && displayTabs">
+                    <p>No playoffs data available.</p>
+                </div>
+                <div v-else id="postSeasonUpcomingGameInfo" class="row row-cols-1 row-cols-md-3 g-4 mt-1">
                     <div class="col" v-for="dataPoint in postSeasonData" :key="dataPoint.id">
                         <GameCardComponent :data = "dataPoint"></GameCardComponent>
                     </div>

--- a/src/components/GamesInfoComponent.vue
+++ b/src/components/GamesInfoComponent.vue
@@ -47,12 +47,6 @@
                         </div>
                     </div>
                 </div>
-
-                <!-- <div v-else id="regularSeasonGameInfo" class="row row-cols-1 row-cols-md-3 g-4 mt-1">
-                    <div class="col" v-for="dataPoint in regularSeasonData" :key="dataPoint.id">
-                        <GameCardComponent :data = "dataPoint"></GameCardComponent>
-                    </div>
-                </div> -->
             </div>
 
             <div class="tab-pane fade" id="playoffs-completed" role="tabpanel" aria-labelledby="playoffs-completed-tab">
@@ -104,10 +98,8 @@ import { nameRetroizer, abbreviationRetroizer } from '../modules/retroizer';
 
         data() {
             return {
-                // regularSeasonData: [],
                 regularSeasonCompletedData: [],
                 regularSeasonUpcomingData: [],
-                // postSeasonData: [],
                 postSeasonCompletedData: [],
                 postSeasonUpcomingData: [],
                 displaySpinner: false,
@@ -140,12 +132,10 @@ import { nameRetroizer, abbreviationRetroizer } from '../modules/retroizer';
                     axios.get("https://free-nba.p.rapidapi.com/games?seasons[]=" + this.season + "&team_ids[]=" + this.team_ids + "&postseason=true&per_page=100&page=1", { headers })
                 ])
                     .then(axios.spread((regular_season_response, postseason_response) => {
-                        // this.regularSeasonData = this.cardDisplayCleanup(regular_season_response.data.data);
                         this.cardDisplayCleanup(regular_season_response.data.data).forEach((item) => {
                             (item.status.toUpperCase() == "FINAL") ? this.regularSeasonCompletedData.push(item) : this.regularSeasonUpcomingData.push(item);
                         });
 
-                        // this.postSeasonData = this.cardDisplayCleanup(postseason_response.data.data);
                         this.cardDisplayCleanup(postseason_response.data.data).forEach((item) => {
                             (item.status.toUpperCase() == "FINAL") ? this.postSeasonCompletedData.push(item) : this.postSeasonUpcomingData.push(item);
                         });

--- a/src/components/GamesInfoComponent.vue
+++ b/src/components/GamesInfoComponent.vue
@@ -64,7 +64,9 @@ import { nameRetroizer, abbreviationRetroizer } from '../modules/retroizer';
 
         data() {
             return {
-                regularSeasonData: [],
+                // regularSeasonData: [],
+                regularSeasonCompletedData: [],
+                regularSeasonUpcomingData: [],
                 postSeasonData: [],
                 displaySpinner: false,
                 displayTabs: false,
@@ -96,7 +98,11 @@ import { nameRetroizer, abbreviationRetroizer } from '../modules/retroizer';
                     axios.get("https://free-nba.p.rapidapi.com/games?seasons[]=" + this.season + "&team_ids[]=" + this.team_ids + "&postseason=true&per_page=100&page=1", { headers })
                 ])
                     .then(axios.spread((regular_season_response, postseason_response) => {
-                        this.regularSeasonData = this.cardDisplayCleanup(regular_season_response.data.data);
+                        // this.regularSeasonData = this.cardDisplayCleanup(regular_season_response.data.data);
+                        this.cardDisplayCleanup(regular_season_response.data.data).forEach((item) => {
+                            (item.status.toUpperCase() == "FINAL") ? this.regularSeasonCompletedData.push(item) : this.regularSeasonUpcomingData.push(item);
+                        })
+
                         this.postSeasonData = this.cardDisplayCleanup(postseason_response.data.data);
                     }))
                     .catch(error => {

--- a/src/components/GamesInfoComponent.vue
+++ b/src/components/GamesInfoComponent.vue
@@ -42,11 +42,7 @@
             </div>
 
             <div class="tab-pane fade" id="regular-season-upcoming" role="tabpanel" aria-labelledby="regular-season-upcoming-tab">
-                <div class="mt-1" v-if="regularSeasonUpcomingData.length < 1 && displayTabs">
-                    <p>No regular season data available.</p>
-                </div>
-
-                <div v-else id="regularSeasonUpcomingGameInfo">
+                <div id="regularSeasonUpcomingGameInfo">
                     <div class="row row-cols-1 row-cols-md-3 g-4 mt-1">
                         <div class="col" v-for="dataPoint in regularSeasonUpcomingData" :key="dataPoint.id">
                             <GameCardComponent :data = "dataPoint"></GameCardComponent>
@@ -67,10 +63,7 @@
             </div>
 
             <div class="tab-pane fade" id="playoffs-upcoming" role="tabpanel" aria-labelledby="playoffs-upcoming-tab">
-                <div class="mt-1" v-if="postSeasonUpcomingData.length < 1 && displayTabs">
-                    <p>No playoffs data available.</p>
-                </div>
-                <div v-else id="postSeasonUpcomingGameInfo" class="row row-cols-1 row-cols-md-3 g-4 mt-1">
+                <div id="postSeasonUpcomingGameInfo" class="row row-cols-1 row-cols-md-3 g-4 mt-1">
                     <div class="col" v-for="dataPoint in postSeasonUpcomingData" :key="dataPoint.id">
                         <GameCardComponent :data = "dataPoint"></GameCardComponent>
                     </div>

--- a/src/components/GamesInfoComponent.vue
+++ b/src/components/GamesInfoComponent.vue
@@ -31,22 +31,17 @@
                 <div class="mt-1" v-if="regularSeasonCompletedData.length < 1 && displayTabs">
                     <p>No regular season data available.</p>
                 </div>
-
-                <div v-else id="regularSeasonCompletedGameInfo">
-                    <div class="row row-cols-1 row-cols-md-3 g-4 mt-1">
-                        <div class="col" v-for="dataPoint in regularSeasonCompletedData" :key="dataPoint.id">
-                            <GameCardComponent :data = "dataPoint"></GameCardComponent>
-                        </div>
+                <div v-else id="regularSeasonCompletedGameInfo" class="row row-cols-1 row-cols-md-3 g-4 mt-1">
+                    <div class="col" v-for="dataPoint in regularSeasonCompletedData" :key="dataPoint.id">
+                        <GameCardComponent :data = "dataPoint"></GameCardComponent>
                     </div>
                 </div>
             </div>
 
             <div class="tab-pane fade" id="regular-season-upcoming" role="tabpanel" aria-labelledby="regular-season-upcoming-tab">
-                <div id="regularSeasonUpcomingGameInfo">
-                    <div class="row row-cols-1 row-cols-md-3 g-4 mt-1">
-                        <div class="col" v-for="dataPoint in regularSeasonUpcomingData" :key="dataPoint.id">
-                            <GameCardComponent :data = "dataPoint"></GameCardComponent>
-                        </div>
+                <div id="regularSeasonUpcomingGameInfo" class="row row-cols-1 row-cols-md-3 g-4 mt-1">
+                    <div class="col" v-for="dataPoint in regularSeasonUpcomingData" :key="dataPoint.id">
+                        <GameCardComponent :data = "dataPoint"></GameCardComponent>
                     </div>
                 </div>
             </div>

--- a/src/components/GamesInfoComponent.vue
+++ b/src/components/GamesInfoComponent.vue
@@ -7,15 +7,21 @@
 
         <ul v-else-if="!displaySpinner && displayTabs" class="nav nav-tabs" id="myTab" role="tablist">
             <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="regular-season-completed-tab" data-bs-toggle="tab" data-bs-target="#regular-season-completed" type="button" role="tab" aria-controls="regular-season-completed" aria-selected="true">Regular Season - Completed</button>
+                <button class="nav-link active" id="regular-season-completed-tab" data-bs-toggle="tab" data-bs-target="#regular-season-completed" type="button" role="tab" aria-controls="regular-season-completed" aria-selected="true">
+                    <span v-if="regularSeasonUpcomingData.length > 0">Regular Season - Completed</span>
+                    <span v-else>Regular Season</span>
+                </button>
             </li>
-            <li class="nav-item" role="presentation">
+            <li v-if="regularSeasonUpcomingData.length > 0" class="nav-item" role="presentation">
                 <button class="nav-link" id="regular-season-upcoming-tab" data-bs-toggle="tab" data-bs-target="#regular-season-upcoming" type="button" role="tab" aria-controls="regular-season-upcoming" aria-selected="false">Regular Season - Upcoming</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="playoffs-completed-tab" data-bs-toggle="tab" data-bs-target="#playoffs-completed" type="button" role="tab" aria-controls="playoffs-completed" aria-selected="false">Playoffs - Completed</button>
+                <button class="nav-link" id="playoffs-completed-tab" data-bs-toggle="tab" data-bs-target="#playoffs-completed" type="button" role="tab" aria-controls="playoffs-completed" aria-selected="false">
+                    <span v-if="postSeasonUpcomingData.length > 0">Playoffs - Completed</span>
+                    <span v-else>Playoffs</span>
+                </button>
             </li>
-            <li class="nav-item" role="presentation">
+            <li v-if="postSeasonUpcomingData.length > 0" class="nav-item" role="presentation">
                 <button class="nav-link" id="playoffs-upcoming-tab" data-bs-toggle="tab" data-bs-target="#playoffs-upcoming" type="button" role="tab" aria-controls="playoffs-upcoming" aria-selected="false">Playoffs - Upcoming</button>
             </li>
         </ul>

--- a/src/components/GamesInfoComponent.vue
+++ b/src/components/GamesInfoComponent.vue
@@ -56,22 +56,22 @@
             </div>
 
             <div class="tab-pane fade" id="playoffs-completed" role="tabpanel" aria-labelledby="playoffs-completed-tab">
-                <div class="mt-1" v-if="postSeasonData.length < 1 && displayTabs">
+                <div class="mt-1" v-if="postSeasonCompletedData.length < 1 && displayTabs">
                     <p>No playoffs data available.</p>
                 </div>
                 <div v-else id="postSeasonCompletedGameInfo" class="row row-cols-1 row-cols-md-3 g-4 mt-1">
-                    <div class="col" v-for="dataPoint in postSeasonData" :key="dataPoint.id">
+                    <div class="col" v-for="dataPoint in postSeasonCompletedData" :key="dataPoint.id">
                         <GameCardComponent :data = "dataPoint"></GameCardComponent>
                     </div>
                 </div>
             </div>
 
             <div class="tab-pane fade" id="playoffs-upcoming" role="tabpanel" aria-labelledby="playoffs-upcoming-tab">
-                <div class="mt-1" v-if="postSeasonData.length < 1 && displayTabs">
+                <div class="mt-1" v-if="postSeasonUpcomingData.length < 1 && displayTabs">
                     <p>No playoffs data available.</p>
                 </div>
                 <div v-else id="postSeasonUpcomingGameInfo" class="row row-cols-1 row-cols-md-3 g-4 mt-1">
-                    <div class="col" v-for="dataPoint in postSeasonData" :key="dataPoint.id">
+                    <div class="col" v-for="dataPoint in postSeasonUpcomingData" :key="dataPoint.id">
                         <GameCardComponent :data = "dataPoint"></GameCardComponent>
                     </div>
                 </div>
@@ -107,7 +107,9 @@ import { nameRetroizer, abbreviationRetroizer } from '../modules/retroizer';
                 // regularSeasonData: [],
                 regularSeasonCompletedData: [],
                 regularSeasonUpcomingData: [],
-                postSeasonData: [],
+                // postSeasonData: [],
+                postSeasonCompletedData: [],
+                postSeasonUpcomingData: [],
                 displaySpinner: false,
                 displayTabs: false,
                 displayStatsModal: false,
@@ -141,9 +143,12 @@ import { nameRetroizer, abbreviationRetroizer } from '../modules/retroizer';
                         // this.regularSeasonData = this.cardDisplayCleanup(regular_season_response.data.data);
                         this.cardDisplayCleanup(regular_season_response.data.data).forEach((item) => {
                             (item.status.toUpperCase() == "FINAL") ? this.regularSeasonCompletedData.push(item) : this.regularSeasonUpcomingData.push(item);
-                        })
+                        });
 
-                        this.postSeasonData = this.cardDisplayCleanup(postseason_response.data.data);
+                        // this.postSeasonData = this.cardDisplayCleanup(postseason_response.data.data);
+                        this.cardDisplayCleanup(postseason_response.data.data).forEach((item) => {
+                            (item.status.toUpperCase() == "FINAL") ? this.postSeasonCompletedData.push(item) : this.postSeasonUpcomingData.push(item);
+                        });
                     }))
                     .catch(error => {
                         console.log(error);

--- a/src/components/GamesInfoComponent.vue
+++ b/src/components/GamesInfoComponent.vue
@@ -7,7 +7,10 @@
 
         <ul v-else-if="!displaySpinner && displayTabs" class="nav nav-tabs" id="myTab" role="tablist">
             <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="regular-season-tab" data-bs-toggle="tab" data-bs-target="#regular-season" type="button" role="tab" aria-controls="regular-season" aria-selected="true">Regular Season</button>
+                <button class="nav-link active" id="regular-season-completed-tab" data-bs-toggle="tab" data-bs-target="#regular-season-completed" type="button" role="tab" aria-controls="regular-season-completed" aria-selected="true">Regular Season - Completed</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="regular-season-upcoming-tab" data-bs-toggle="tab" data-bs-target="#regular-season-upcoming" type="button" role="tab" aria-controls="regular-season-upcoming" aria-selected="false">Regular Season - Upcoming</button>
             </li>
             <li class="nav-item" role="presentation">
                 <button class="nav-link" id="playoffs-tab" data-bs-toggle="tab" data-bs-target="#playoffs" type="button" role="tab" aria-controls="playoffs" aria-selected="false">Playoffs</button>
@@ -15,15 +18,38 @@
         </ul>
         
         <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade show active" id="regular-season" role="tabpanel" aria-labelledby="regular-season-tab">
-                <div class="mt-1" v-if="regularSeasonData.length < 1 && displayTabs">
+            <div class="tab-pane fade show active" id="regular-season-completed" role="tabpanel" aria-labelledby="regular-season-completed-tab">
+                <div class="mt-1" v-if="regularSeasonCompletedData.length < 1 && displayTabs">
                     <p>No regular season data available.</p>
                 </div>
-                <div v-else id="regularSeasonGameInfo" class="row row-cols-1 row-cols-md-3 g-4 mt-1">
+
+                <div v-else id="regularSeasonCompletedGameInfo">
+                    <div class="row row-cols-1 row-cols-md-3 g-4 mt-1">
+                        <div class="col" v-for="dataPoint in regularSeasonCompletedData" :key="dataPoint.id">
+                            <GameCardComponent :data = "dataPoint"></GameCardComponent>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="tab-pane fade" id="regular-season-upcoming" role="tabpanel" aria-labelledby="regular-season-upcoming-tab">
+                <div class="mt-1" v-if="regularSeasonUpcomingData.length < 1 && displayTabs">
+                    <p>No regular season data available.</p>
+                </div>
+
+                <div v-else id="regularSeasonUpcomingGameInfo">
+                    <div class="row row-cols-1 row-cols-md-3 g-4 mt-1">
+                        <div class="col" v-for="dataPoint in regularSeasonUpcomingData" :key="dataPoint.id">
+                            <GameCardComponent :data = "dataPoint"></GameCardComponent>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- <div v-else id="regularSeasonGameInfo" class="row row-cols-1 row-cols-md-3 g-4 mt-1">
                     <div class="col" v-for="dataPoint in regularSeasonData" :key="dataPoint.id">
                         <GameCardComponent :data = "dataPoint"></GameCardComponent>
                     </div>
-                </div>
+                </div> -->
             </div>
 
             <div class="tab-pane fade" id="playoffs" role="tabpanel" aria-labelledby="playoffs-tab">


### PR DESCRIPTION
logic will now do a few things: 
- if the season has completed, only "regular season" and "playoffs" tabs will be displayed.
- if the season is currently active and playoffs haven't started, "regular season - completed" and "regular season - upcoming" will be displayed. a "playoffs" tab will be displayed, but no data will be populated.
- if the season is currently active, and the selected is slated for the playoffs, "playoffs - completed" and "playoffs - upcoming" will be rendered.